### PR TITLE
DQA-4743: Allow robo version 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "consolidation/robo": "^3.0"
+    "consolidation/robo": "^3.0 | ^4.0"
   },
   "require-dev": {
     "drupal/coder": "^8",


### PR DESCRIPTION
## DQA-4743

### Description

We are working on Toolkit to make it compatible with the Drupal 10.
In this Pull request I am just allowing the installation of Robo version 4.
Here's the change log https://github.com/consolidation/robo/compare/3.0.10...4.0.0-alpha1
